### PR TITLE
:beetle: wcのせいでテストケース数が狂う

### DIFF
--- a/utest.sh
+++ b/utest.sh
@@ -11,7 +11,7 @@ TIMEFMT='%J   %U  user %S system %P cpu %*E total'$'\n'\
 TESTCASES='testcases/testcases.em'
 TESTCASES_DIRECTORY='testcases'
 
-line_count=`cat $TESTCASES | wc -l`
+line_count=`cat $TESTCASES | wc -l | sed -e 's/ //g'`
 
 if [ "$1" = "v" ] ; then
     echo "wwwwwww TESTING wwwwwwww"


### PR DESCRIPTION
`expr: not a decimal number: '      86'` と出ていたので調べてみると `wc -l` の出力が右詰めのため unittest.sh の 22 行目のexprで失敗して `seq 0` が実行されてしまっていました。